### PR TITLE
Adding support for supplementary characters in RequestBuilder.setStringInput

### DIFF
--- a/WebServiceManager/src/com/raizlabs/net/requests/RequestBuilder.java
+++ b/WebServiceManager/src/com/raizlabs/net/requests/RequestBuilder.java
@@ -264,7 +264,7 @@ public class RequestBuilder {
 	 * @return This {@link RequestBuilder} object to allow for chaining of calls.
 	 */
 	public RequestBuilder setStringInput(String string, ProgressListener progressListener) {
-		setInputStream(IOUtils.getInputStream(string), string.length(), progressListener);
+		setInputStream(IOUtils.getInputStream(string), string.getBytes().length, progressListener);
 		
 		return this;
 	}


### PR DESCRIPTION
Some characters in Java strings are of length 1, but actually are represented as two bytes (examples: ñ × 😎). Therefore, the calculation in RequestBuilder.setStringInput is incorrect.

[Java Unicode Documentation](http://docs.oracle.com/javase/tutorial/i18n/text/unicode.html)
